### PR TITLE
fix(soundness): use `&raw` pointers for Node/Link field access, organize unsafe contracts, and deprecate `update_flags`

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -279,7 +279,7 @@ pub(crate) fn check_dirty(mut link: Link, mut sub: Node) -> bool {
                 }
                 dirty = false;
             } else {
-                sub.update_flags(|f| *f &= !Flags::PENDING);
+                sub.remove_flags(Flags::PENDING);
             }
 
             sub = link.sub();
@@ -305,7 +305,7 @@ pub(crate) fn shallow_propagate(mut link: Link) {
         let flags = sub.flags();
 
         if (flags & (Flags::PENDING | Flags::DIRTY)) == Flags::PENDING {
-            sub.update_flags(|f| *f |= Flags::DIRTY);
+            sub.add_flags(Flags::DIRTY);
             if (flags & (Flags::WATCHING | Flags::RECURSED_CHECK)) == Flags::WATCHING {
                 super::notify(
                     sub.try_into()

--- a/tests/effect_spec.rs
+++ b/tests/effect_spec.rs
@@ -353,7 +353,7 @@ fn should_support_custom_recurse_effect() {
         move || {
             alien_signals::get_active_sub()
                 .unwrap()
-                .update_flags(|f| *f &= !alien_signals::Flags::RECURSED_CHECK);
+                .remove_flags(alien_signals::Flags::RECURSED_CHECK);
             *triggers.lock().unwrap() += 1;
             src.set(i32::min(src.get() + 1, 5));
         }


### PR DESCRIPTION
## Summary
This PR refactors `Node`/`Link` field accessors (e.g. `.flags()`, `.set_flags()`, etc.) to use `&raw` pointers instead of creating intermediate references.

## Why
Previously, creating `&mut NodeFields`/`&LinkFields` inside accessors would invalidate other existing pointers to the same node potentially leading to Undefined Behavior (Stacked Borrows violation), especially around `Node::{context, update_context}`.

## Changes
- Switched to `&raw const` / `&raw mut` for fine-grained field access without borrowing the entire struct.
- Clarified safety comments and preconditions for unsafe blocks.
- Deprecated `Node::update_flags` and provide `Node::{add, remove}_flags` to ensure safety.